### PR TITLE
AMBARI-24763. Infra Solr upgrade (2.7.x): ValueError: invalid literal for float():

### DIFF
--- a/ambari-infra-solr-client/src/main/python/migrationHelper.py
+++ b/ambari-infra-solr-client/src/main/python/migrationHelper.py
@@ -946,9 +946,10 @@ def human_size(size_bytes):
   return "%s %s" % (formatted_size, suffix)
 
 def parse_size(human_size):
+  import locale
   units = {"bytes": 1, "KB": 1024, "MB": 1024**2, "GB": 1024**3, "TB": 1024**4 }
   number, unit = [string.strip() for string in human_size.split()]
-  return int(float(number)*units[unit])
+  return int(locale.atof(number)*units[unit])
 
 def get_replica_index_size(config, core_url, replica):
   request = CORE_DETAILS_URL.format(core_url)


### PR DESCRIPTION
## What changes were proposed in this pull request?
in some cases (probably system environment problem? ), invalid float literals can be invalid. fixing that by using locale

## How was this patch tested?
manually by someone else

Please review @zeroflag @adoroszlai @g-boros @kasakrisz @swagle 
