### PR TITLE
AMBARI-24792 - Infra Manager: not all the documents archived

### DIFF
--- a/ambari-infra-manager-it/src/test/java/org/apache/ambari/infra/S3Client.java
+++ b/ambari-infra-manager-it/src/test/java/org/apache/ambari/infra/S3Client.java
@@ -96,4 +96,13 @@ public class S3Client {
       throw new RuntimeException(e);
     }
   }
+
+  public InputStream getObject(String key) {
+    try {
+      return s3client.getObject(bucket, key);
+    }
+    catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
 }

--- a/ambari-infra-manager-it/src/test/java/org/apache/ambari/infra/steps/AbstractInfraSteps.java
+++ b/ambari-infra-manager-it/src/test/java/org/apache/ambari/infra/steps/AbstractInfraSteps.java
@@ -114,7 +114,7 @@ public abstract class AbstractInfraSteps {
     }
   }
 
-  protected void addDocument(OffsetDateTime logtime) {
+  protected SolrInputDocument addDocument(OffsetDateTime logtime) {
     SolrInputDocument solrInputDocument = new SolrInputDocument();
     solrInputDocument.addField("logType", "HDFSAudit");
     solrInputDocument.addField("cluster", "cl1");
@@ -148,6 +148,7 @@ public abstract class AbstractInfraSteps {
     solrInputDocument.addField("_ttl_", "+7DAYS");
     solrInputDocument.addField("_expire_at_", "2017-12-15T10:23:19.106Z");
     solr.add(solrInputDocument);
+    return solrInputDocument;
   }
 
   @AfterStories

--- a/ambari-infra-manager-it/src/test/resources/stories/infra_api_tests.story
+++ b/ambari-infra-manager-it/src/test/resources/stories/infra_api_tests.story
@@ -11,6 +11,7 @@ Given 10 documents in solr with logtime from 2010-10-09T05:00:00.000Z to 2010-10
 When start archive_audit_logs job with parameters writeBlockSize=3,start=2010-10-09T00:00:00.000Z,end=2010-10-11T00:00:00.000Z after 2 seconds
 Then Check 4 files exists on s3 server with filenames containing the text solr_archive_audit_logs_-_2010-10-09 after 20 seconds
 And solr does not contain documents between 2010-10-09T05:00:00.000Z and 2010-10-09T20:00:00.000Z after 5 seconds
+And Check the files solr_archive_audit_logs_-_2010-10-09 contains the archived documents
 
 
 Scenario: Running archiving job with a bigger start value than end value exports and deletes 0 documents
@@ -32,6 +33,7 @@ When delete file with key solr_archive_audit_logs_-_2011-10-09T08-00-00.000Z.jso
 And restart archive_audit_logs job within 2 seconds
 Then Check 10 files exists on s3 server with filenames containing the text solr_archive_audit_logs_-_2011-10-09 after 20 seconds
 And solr does not contain documents between 2011-10-09T05:00:00.000Z and 2011-10-09T20:00:00.000Z after 5 seconds
+And Check the files solr_archive_audit_logs_-_2011-10-09 contains the archived documents
 
 
 Scenario: After Deleting job deletes documents from solr no document found in the specified interval
@@ -65,3 +67,4 @@ And stop job archive_audit_logs after at least 1 file exists in s3 with filename
 Then Less than 20 files exists on s3 server with filenames containing the text solr_archive_audit_logs_-_2014-03-09 after 20 seconds
 When restart archive_audit_logs job within 10 seconds
 Then Check 25 files exists on s3 server with filenames containing the text solr_archive_audit_logs_-_2014-03-09 after 20 seconds
+And Check the files solr_archive_audit_logs_-_2014-03-09 contains the archived documents

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/SolrProperties.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/SolrProperties.java
@@ -94,7 +94,12 @@ public class SolrProperties {
       sortColumns.add(sortValue);
       ++i;
     }
-    solrParameters.setSortColumn(sortColumns.toArray(new String[0]));
+    if (!sortColumns.isEmpty()) {
+      solrParameters.setSortColumn(sortColumns.toArray(new String[0]));
+    }
+    else {
+      solrParameters.setSortColumn(sortColumn);
+    }
 
     return solrParameters;
   }

--- a/ambari-infra-manager/src/test/java/org/apache/ambari/infra/job/archive/SolrPropertiesTest.java
+++ b/ambari-infra-manager/src/test/java/org/apache/ambari/infra/job/archive/SolrPropertiesTest.java
@@ -1,6 +1,7 @@
 package org.apache.ambari.infra.job.archive;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -27,7 +28,7 @@ import org.springframework.batch.core.JobParametersBuilder;
  */
 public class  SolrPropertiesTest {
   @Test
-  public void testApplySortColumns() {
+  public void testMergeSortColumns() {
     JobParameters jobParameters = new JobParametersBuilder()
             .addString("sortColumn[0]", "logtime")
             .addString("sortColumn[1]", "id")
@@ -42,13 +43,24 @@ public class  SolrPropertiesTest {
   }
 
   @Test
-  public void testApplyWhenNoSortIsDefined() {
+  public void testMergeWhenNoSortIsDefined() {
+    JobParameters jobParameters = new JobParametersBuilder()
+            .toJobParameters();
+
+    SolrProperties solrProperties = new SolrProperties();
+    SolrParameters solrParameters = solrProperties.merge(jobParameters);
+    assertThat(solrParameters.getSortColumn(), is(nullValue()));
+  }
+
+  @Test
+  public void testMergeWhenPropertiesAreDefinedButJobParamsAreNot() {
     JobParameters jobParameters = new JobParametersBuilder()
             .toJobParameters();
 
     SolrProperties solrProperties = new SolrProperties();
     solrProperties.setSortColumn(new String[] {"testColumn"});
     SolrParameters solrParameters = solrProperties.merge(jobParameters);
-    assertThat(solrParameters.getSortColumn().length, is(0));
+    assertThat(solrParameters.getSortColumn().length, is(1));
+    assertThat(solrParameters.getSortColumn()[0], is("testColumn"));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Infra manager did not use the sort_column properties when reading the documents to archive. This lead to some of the documents are not exported when the read block size was less than the number of documents to export and no sort_column were specified by job parameters.
Fix: copy the sort_column properties to the actual ArchivingParameters instance if job parameters are not given.
2. Add integration test to check if all the documents are archived.

## How was this patch tested?

UTs and ITs passed.

Manually:
1. Deploy Ambari and a cluster including infra solr, zookeeper, logsearch to a vagrant env
2. When service logs collection has some documents stop Logsearch after a while to prevent producing more service log documents.
3. Run Infra Manager from Idea
4. Start `archive_service_logs` job by specifying an interval end value of now, a read block size smaller than the service logs collection size and a local destination only
5. Check the files in the local folder contains all the documents were stored in service logs and service logs collection is empty in Solr
