### PR TITLE
AMBARI-24807 - Infra Manager: unable to restart job

### DIFF
--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/JobScheduler.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/JobScheduler.java
@@ -63,12 +63,14 @@ public class JobScheduler {
   }
 
   private void restartIfFailed(JobExecution jobExecution) {
-    if (jobExecution.getExitStatus() == ExitStatus.FAILED) {
-      try {
+    try {
+      if (ExitStatus.FAILED.compareTo(jobExecution.getExitStatus()) == 0) {
         jobs.restart(jobExecution.getId());
-      } catch (JobInstanceAlreadyCompleteException | NoSuchJobException | JobExecutionAlreadyRunningException | JobRestartException | JobParametersInvalidException | NoSuchJobExecutionException e) {
-        throw new RuntimeException(e);
+      } else if (ExitStatus.UNKNOWN.compareTo(jobExecution.getExitStatus()) == 0) {
+        jobs.abandon(jobExecution.getId());
       }
+    } catch (JobInstanceAlreadyCompleteException | NoSuchJobException | JobExecutionAlreadyRunningException | JobRestartException | JobParametersInvalidException | NoSuchJobExecutionException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/manager/JobManager.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/manager/JobManager.java
@@ -18,7 +18,19 @@
  */
 package org.apache.ambari.infra.manager;
 
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TimeZone;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import org.apache.ambari.infra.model.ExecutionContextResponse;
 import org.apache.ambari.infra.model.JobDetailsResponse;
 import org.apache.ambari.infra.model.JobExecutionDetailsResponse;
@@ -50,17 +62,7 @@ import org.springframework.batch.core.repository.JobExecutionAlreadyRunningExcep
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRestartException;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TimeZone;
+import com.google.common.collect.Lists;
 
 @Named
 public class JobManager implements Jobs {
@@ -108,6 +110,11 @@ public class JobManager implements Jobs {
   @Override
   public Optional<JobExecution> lastRun(String jobName) throws NoSuchJobException {
     return jobService.listJobExecutionsForJob(jobName, 0, 1).stream().findFirst();
+  }
+
+  @Override
+  public void abandon(Long jobExecution) throws NoSuchJobExecutionException, JobExecutionAlreadyRunningException {
+    jobService.abandon(jobExecution);
   }
 
   /**

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/manager/Jobs.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/manager/Jobs.java
@@ -18,6 +18,8 @@
  */
 package org.apache.ambari.infra.manager;
 
+import java.util.Optional;
+
 import org.apache.ambari.infra.model.JobExecutionInfoResponse;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
@@ -28,8 +30,6 @@ import org.springframework.batch.core.repository.JobExecutionAlreadyRunningExcep
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRestartException;
 
-import java.util.Optional;
-
 public interface Jobs {
   JobExecutionInfoResponse launchJob(String jobName, JobParameters params)
           throws JobParametersInvalidException, NoSuchJobException,
@@ -39,4 +39,6 @@ public interface Jobs {
           JobParametersInvalidException, JobRestartException, NoSuchJobExecutionException;
 
   Optional<JobExecution> lastRun(String jobName) throws NoSuchJobException, NoSuchJobExecutionException;
+
+  void abandon(Long jobExecution) throws NoSuchJobExecutionException, JobExecutionAlreadyRunningException;
 }

--- a/ambari-infra-manager/src/main/resources/infra-manager.properties
+++ b/ambari-infra-manager/src/main/resources/infra-manager.properties
@@ -83,6 +83,6 @@ infra-manager.jobs.solr_data_deleting.delete_audit_logs.enabled=true
 infra-manager.jobs.solr_data_deleting.delete_audit_logs.zoo_keeper_connection_string=zookeeper:2181
 infra-manager.jobs.solr_data_deleting.delete_audit_logs.collection=audit_logs
 infra-manager.jobs.solr_data_deleting.delete_audit_logs.filter_field=evtTime
-infra-manager.jobs.clean-up.ttl=PT24H
+infra-manager.jobs.clean-up.ttl=PT240H
 infra-manager.jobs.clean-up.scheduling.enabled=true
 infra-manager.jobs.clean-up.scheduling.cron=0 * * * * ?


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a job is running and a stop signal is sent just right after the infra manager process is killed the job remains in Stopping/Unknown state.
In this case the job won't be restarted when Infra Manager is restarted and also a new instance of the job can not be scheduled.
Fix.: Since the job and the database is in an inconsistent state abandon the job.
Archive jobs are delete the chunk of documents only if the chunk was successfully persisted to its destination. 

## How was this patch tested?

UTs and ITs passed

Manually:
1. I have an inconsistent job database with a job in an unknown state.
2. Start Infra manager using this database
3. Start a new instance of the job which state was unknown
