### PR TITLE
AMBARI-24832 - Infra Manager: set archive file permission on hdfs to 640

### DIFF
--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/FsPermissionConverter.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/FsPermissionConverter.java
@@ -18,21 +18,20 @@
  */
 package org.apache.ambari.infra.conf;
 
-import static org.apache.ambari.infra.json.StringToDurationConverter.toDuration;
-
-import java.time.Duration;
+import static org.apache.ambari.infra.json.StringToFsPermissionConverter.toFsPermission;
 
 import javax.annotation.Nullable;
 import javax.inject.Named;
 
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 import org.springframework.core.convert.converter.Converter;
 
 @Named
 @ConfigurationPropertiesBinding
-public class DurationConverter implements Converter<String, Duration> {
+public class FsPermissionConverter implements Converter<String, FsPermission> {
   @Override
-  public Duration convert(@Nullable String s) {
-    return toDuration(s);
+  public FsPermission convert(@Nullable String s) {
+    return toFsPermission(s);
   }
 }

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/ArchivingParameters.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/ArchivingParameters.java
@@ -29,7 +29,9 @@ import java.util.Optional;
 
 import org.apache.ambari.infra.job.Validatable;
 import org.apache.ambari.infra.json.DurationToStringConverter;
+import org.apache.ambari.infra.json.FsPermissionToStringConverter;
 import org.apache.ambari.infra.json.StringToDurationConverter;
+import org.apache.ambari.infra.json.StringToFsPermissionConverter;
 import org.apache.hadoop.fs.permission.FsPermission;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -49,6 +51,8 @@ public class ArchivingParameters implements Validatable {
   private String s3Endpoint;
   private String hdfsEndpoint;
   private String hdfsDestinationDirectory;
+  @JsonSerialize(converter = FsPermissionToStringConverter.class)
+  @JsonDeserialize(converter = StringToFsPermissionConverter.class)
   private FsPermission hdfsFilePermission;
   private String start;
   private String end;

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/ArchivingParameters.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/ArchivingParameters.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import org.apache.ambari.infra.job.Validatable;
 import org.apache.ambari.infra.json.DurationToStringConverter;
 import org.apache.ambari.infra.json.StringToDurationConverter;
+import org.apache.hadoop.fs.permission.FsPermission;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -48,6 +49,7 @@ public class ArchivingParameters implements Validatable {
   private String s3Endpoint;
   private String hdfsEndpoint;
   private String hdfsDestinationDirectory;
+  private FsPermission hdfsFilePermission;
   private String start;
   private String end;
   @JsonSerialize(converter = DurationToStringConverter.class)
@@ -156,6 +158,14 @@ public class ArchivingParameters implements Validatable {
 
   public void setHdfsDestinationDirectory(String hdfsDestinationDirectory) {
     this.hdfsDestinationDirectory = hdfsDestinationDirectory;
+  }
+
+  public FsPermission getHdfsFilePermission() {
+    return hdfsFilePermission;
+  }
+
+  public void setHdfsFilePermission(FsPermission hdfsFilePermission) {
+    this.hdfsFilePermission = hdfsFilePermission;
   }
 
   public Optional<S3Properties> s3Properties() {

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/DocumentArchivingConfiguration.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/DocumentArchivingConfiguration.java
@@ -104,7 +104,7 @@ public class DocumentArchivingConfiguration extends AbstractJobsConfiguration<Do
       case HDFS:
         org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
         conf.set("fs.defaultFS", parameters.getHdfsEndpoint());
-        fileAction.add(new HdfsUploader(conf, new Path(parameters.getHdfsDestinationDirectory())));
+        fileAction.add(new HdfsUploader(conf, new Path(parameters.getHdfsDestinationDirectory()), parameters.getHdfsFilePermission()));
         break;
       case LOCAL:
         baseDir = new File(parameters.getLocalDestinationDirectory());

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/DocumentArchivingProperties.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/DocumentArchivingProperties.java
@@ -19,6 +19,7 @@
 package org.apache.ambari.infra.job.archive;
 
 import static org.apache.ambari.infra.json.StringToDurationConverter.toDuration;
+import static org.apache.ambari.infra.json.StringToFsPermissionConverter.toFsPermission;
 import static org.apache.commons.lang.StringUtils.isBlank;
 
 import java.time.Duration;
@@ -26,6 +27,8 @@ import java.util.Optional;
 
 import org.apache.ambari.infra.job.JobProperties;
 import org.apache.ambari.infra.json.DurationToStringConverter;
+import org.apache.ambari.infra.json.FsPermissionToStringConverter;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.springframework.batch.core.JobParameters;
 
 public class DocumentArchivingProperties extends JobProperties<ArchivingParameters> {
@@ -44,6 +47,7 @@ public class DocumentArchivingProperties extends JobProperties<ArchivingParamete
 
   private String hdfsEndpoint;
   private String hdfsDestinationDirectory;
+  private FsPermission hdfsFilePermission;
 
   public int getReadBlockSize() {
     return readBlockSize;
@@ -164,6 +168,14 @@ public class DocumentArchivingProperties extends JobProperties<ArchivingParamete
     return hdfsDestinationDirectory;
   }
 
+  public FsPermission getHdfsFilePermission() {
+    return hdfsFilePermission;
+  }
+
+  public void setHdfsFilePermission(FsPermission hdfsFilePermission) {
+    this.hdfsFilePermission = hdfsFilePermission;
+  }
+
   public void setHdfsDestinationDirectory(String hdfsDestinationDirectory) {
     this.hdfsDestinationDirectory = hdfsDestinationDirectory;
   }
@@ -190,6 +202,7 @@ public class DocumentArchivingProperties extends JobProperties<ArchivingParamete
     archivingParameters.setS3Endpoint(jobParameters.getString("s3Endpoint", s3Endpoint));
     archivingParameters.setHdfsEndpoint(jobParameters.getString("hdfsEndpoint", hdfsEndpoint));
     archivingParameters.setHdfsDestinationDirectory(jobParameters.getString("hdfsDestinationDirectory", hdfsDestinationDirectory));
+    archivingParameters.setHdfsFilePermission(toFsPermission(jobParameters.getString("hdfsFilePermission", FsPermissionToStringConverter.toString(hdfsFilePermission))));
     archivingParameters.setSolr(solr.merge(jobParameters));
     archivingParameters.setStart(jobParameters.getString("start"));
     archivingParameters.setEnd(jobParameters.getString("end"));

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/HdfsUploader.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/HdfsUploader.java
@@ -18,22 +18,26 @@
  */
 package org.apache.ambari.infra.job.archive;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+
 public class HdfsUploader extends AbstractFileAction {
 
+  private static final String DEFAULT_FILE_PERMISSION = "640";
   private final Configuration configuration;
   private final Path destinationDirectory;
+  private final FsPermission fsPermission;
 
-  public HdfsUploader(Configuration configuration, Path destinationDirectory) {
+  public HdfsUploader(Configuration configuration, Path destinationDirectory, FsPermission fsPermission) {
     this.destinationDirectory = destinationDirectory;
     this.configuration = configuration;
+    this.fsPermission = fsPermission == null ? new FsPermission(DEFAULT_FILE_PERMISSION) : fsPermission;
   }
 
   @Override
@@ -45,6 +49,7 @@ public class HdfsUploader extends AbstractFileAction {
       }
 
       fileSystem.copyFromLocalFile(new Path(inputFile.getAbsolutePath()), destination);
+      fileSystem.setPermission(destination, fsPermission);
 
       return inputFile;
     }

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/json/FsPermissionToStringConverter.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/json/FsPermissionToStringConverter.java
@@ -16,23 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.ambari.infra.conf;
+package org.apache.ambari.infra.json;
 
-import static org.apache.ambari.infra.json.StringToDurationConverter.toDuration;
+import org.apache.hadoop.fs.permission.FsPermission;
 
-import java.time.Duration;
+import com.fasterxml.jackson.databind.util.StdConverter;
 
-import javax.annotation.Nullable;
-import javax.inject.Named;
-
-import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
-import org.springframework.core.convert.converter.Converter;
-
-@Named
-@ConfigurationPropertiesBinding
-public class DurationConverter implements Converter<String, Duration> {
+public class FsPermissionToStringConverter extends StdConverter<FsPermission, String> {
   @Override
-  public Duration convert(@Nullable String s) {
-    return toDuration(s);
+  public String convert(FsPermission value) {
+    return toString(value);
+  }
+
+  public static String toString(FsPermission value) {
+    return value == null ? null : Short.toString(value.toOctal());
   }
 }

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/json/StringToFsPermissionConverter.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/json/StringToFsPermissionConverter.java
@@ -16,23 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.ambari.infra.conf;
+package org.apache.ambari.infra.json;
 
-import static org.apache.ambari.infra.json.StringToDurationConverter.toDuration;
+import static org.apache.commons.lang.StringUtils.isBlank;
 
-import java.time.Duration;
+import org.apache.hadoop.fs.permission.FsPermission;
 
-import javax.annotation.Nullable;
-import javax.inject.Named;
+import com.fasterxml.jackson.databind.util.StdConverter;
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
-import org.springframework.core.convert.converter.Converter;
-
-@Named
-@ConfigurationPropertiesBinding
-public class DurationConverter implements Converter<String, Duration> {
+public class StringToFsPermissionConverter extends StdConverter<String, FsPermission> {
   @Override
-  public Duration convert(@Nullable String s) {
-    return toDuration(s);
+  public FsPermission convert(String value) {
+    return toFsPermission(value);
+  }
+
+  public static FsPermission toFsPermission(String value) {
+    return isBlank(value) ? null : new FsPermission(value);
   }
 }

--- a/ambari-infra-manager/src/test/java/org/apache/ambari/infra/json/FsPermissionToStringConverterTest.java
+++ b/ambari-infra-manager/src/test/java/org/apache/ambari/infra/json/FsPermissionToStringConverterTest.java
@@ -1,3 +1,12 @@
+package org.apache.ambari.infra.json;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.junit.Test;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -16,23 +25,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.ambari.infra.conf;
+public class FsPermissionToStringConverterTest {
+  @Test
+  public void testConvertWhenInputIsNotNull() {
+    assertThat(new FsPermissionToStringConverter().convert(new FsPermission("640")), is("640"));
+  }
 
-import static org.apache.ambari.infra.json.StringToDurationConverter.toDuration;
-
-import java.time.Duration;
-
-import javax.annotation.Nullable;
-import javax.inject.Named;
-
-import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
-import org.springframework.core.convert.converter.Converter;
-
-@Named
-@ConfigurationPropertiesBinding
-public class DurationConverter implements Converter<String, Duration> {
-  @Override
-  public Duration convert(@Nullable String s) {
-    return toDuration(s);
+  @Test
+  public void testConvertWhenInputIsNull() {
+    assertThat(new FsPermissionToStringConverter().convert(null), is(nullValue()));
   }
 }

--- a/ambari-infra-manager/src/test/java/org/apache/ambari/infra/json/FsPermissionToStringConverterTest.java
+++ b/ambari-infra-manager/src/test/java/org/apache/ambari/infra/json/FsPermissionToStringConverterTest.java
@@ -1,12 +1,3 @@
-package org.apache.ambari.infra.json;
-
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-
-import org.apache.hadoop.fs.permission.FsPermission;
-import org.junit.Test;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -25,6 +16,15 @@ import org.junit.Test;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.ambari.infra.json;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.junit.Test;
+
 public class FsPermissionToStringConverterTest {
   @Test
   public void testConvertWhenInputIsNotNull() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When archiving solr documents to hdfs set the permission of the files to 640

## How was this patch tested?

UTs and ITs passed.

Manually:

1. Deploy Ambari and a cluster: zookeeper, hdfs infra solr, infra manager, logsearch
2. Enable archiving service logs and set the destination to Hdfs
3. Start the archiver_service_logs job using Infra Manager rest api
4. Check the files permission on hdfs in the specified destination directory 
