### PR TITLE
AMBARI-24838 - Infra Manager: zookeper connection string

### DIFF
--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/SolrDAOBase.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/SolrDAOBase.java
@@ -21,6 +21,7 @@ package org.apache.ambari.infra.job;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -62,9 +63,11 @@ public abstract class SolrDAOBase {
 
   protected CloudSolrClient createClient() {
     ConnectStringParser connectStringParser = new ConnectStringParser(zooKeeperConnectionString);
+    List<String> zkHosts = connectStringParser.getServerAddresses().stream()
+            .map(InetSocketAddress::toString)
+            .collect(Collectors.toList());
     CloudSolrClient client = new CloudSolrClient.Builder(
-            connectStringParser.getServerAddresses().stream().map(InetSocketAddress::toString).collect(Collectors.toList()),
-            Optional.ofNullable(connectStringParser.getChrootPath())).build();
+            zkHosts, Optional.ofNullable(connectStringParser.getChrootPath())).build();
     client.setDefaultCollection(defaultCollection);
     return client;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Infra Manager can not connect to zookeeper if it is installed into a node where there is no zookeeper server instance.
The builder which is used for construct an org.apache.solr.client.solrj.impl.CloudSolrClient instance is deprecated: it does not handle the zookeper connection string fromat which sould be set in the stack code.
```
zkhost0:port[,zkhost1:port...zkhostn:port][/solr_znode]
```

## How was this patch tested?

ITs passed

Manually:
1. Deploy Ambari and a cluster: zookeeper, infra solr, logsearch
2. Deploy Infra manager to a node where no zookeeper server is installed
3. Run archive_service_logs job
4. Check that archive files exists in the specified destination directory

