### PR TITLE
AMBARI-24807 - ADDENDUM Infra Manager: unable to restart job

### DIFF
--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/JobScheduler.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/JobScheduler.java
@@ -67,7 +67,7 @@ public class JobScheduler {
       if (ExitStatus.FAILED.compareTo(jobExecution.getExitStatus()) == 0) {
         jobs.restart(jobExecution.getId());
       } else if (ExitStatus.UNKNOWN.compareTo(jobExecution.getExitStatus()) == 0) {
-        jobs.abandon(jobExecution.getId());
+        jobs.stopAndAbandon(jobExecution.getId());
       }
     } catch (JobInstanceAlreadyCompleteException | NoSuchJobException | JobExecutionAlreadyRunningException | JobRestartException | JobParametersInvalidException | NoSuchJobExecutionException e) {
       throw new RuntimeException(e);

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/manager/JobManager.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/manager/JobManager.java
@@ -113,8 +113,13 @@ public class JobManager implements Jobs {
   }
 
   @Override
-  public void abandon(Long jobExecution) throws NoSuchJobExecutionException, JobExecutionAlreadyRunningException {
-    jobService.abandon(jobExecution);
+  public void stopAndAbandon(Long jobExecutionId) throws NoSuchJobExecutionException, JobExecutionAlreadyRunningException {
+    try {
+      jobService.stop(jobExecutionId);
+    } catch (JobExecutionNotRunningException e) {
+      LOG.warn(String.format("Job is not running jobExecutionId=%d", jobExecutionId), e.getMessage());
+    }
+    jobService.abandon(jobExecutionId);
   }
 
   /**

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/manager/Jobs.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/manager/Jobs.java
@@ -40,5 +40,5 @@ public interface Jobs {
 
   Optional<JobExecution> lastRun(String jobName) throws NoSuchJobException, NoSuchJobExecutionException;
 
-  void abandon(Long jobExecution) throws NoSuchJobExecutionException, JobExecutionAlreadyRunningException;
+  void stopAndAbandon(Long jobExecution) throws NoSuchJobExecutionException, JobExecutionAlreadyRunningException;
 }

--- a/ambari-infra-manager/src/test/java/org/apache/ambari/infra/job/JobSchedulerTest.java
+++ b/ambari-infra-manager/src/test/java/org/apache/ambari/infra/job/JobSchedulerTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.ambari.infra.job;
 
 import static org.easymock.EasyMock.eq;
@@ -24,24 +42,6 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 @RunWith(EasyMockRunner.class)
 public class JobSchedulerTest extends EasyMockSupport {
 
@@ -54,12 +54,12 @@ public class JobSchedulerTest extends EasyMockSupport {
   private JobScheduler jobScheduler;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     jobScheduler = new JobScheduler(taskScheduler, jobs);
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     verifyAll();
   }
 
@@ -121,7 +121,7 @@ public class JobSchedulerTest extends EasyMockSupport {
     JobExecution jobExecution = new JobExecution(1L, new JobParameters());
     jobExecution.setExitStatus(ExitStatus.UNKNOWN);
     expect(jobs.lastRun(jobName)).andReturn(Optional.of(jobExecution));
-    jobs.abandon(1L); expectLastCall();
+    jobs.stopAndAbandon(1L); expectLastCall();
     expect(taskScheduler.schedule(isA(Runnable.class), eq(new CronTrigger(schedulingProperties.getCron())))).andReturn(scheduledFuture);
     replayAll();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to #9 
But in this case the job was in a `STARTED`  state when Infra Manager was killed.
A started job can not be abandoned. It must be stopped first.

## How was this patch tested?

same as #9 