### PR TITLE
AMBARI-24878 - Infra Manager: kerberos support

### DIFF
--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/DocumentArchivingConfiguration.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/DocumentArchivingConfiguration.java
@@ -32,7 +32,6 @@ import org.apache.ambari.infra.job.AbstractJobsConfiguration;
 import org.apache.ambari.infra.job.JobContextRepository;
 import org.apache.ambari.infra.job.JobScheduler;
 import org.apache.ambari.infra.job.ObjectSource;
-import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.Job;
@@ -103,8 +102,8 @@ public class DocumentArchivingConfiguration extends AbstractJobsConfiguration<Do
         break;
       case HDFS:
         org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
-        conf.set("fs.defaultFS", parameters.getHdfsEndpoint());
-        fileAction.add(new HdfsUploader(conf, new Path(parameters.getHdfsDestinationDirectory()), parameters.getHdfsFilePermission()));
+        fileAction.add(new HdfsUploader(conf,
+                parameters.hdfsProperties().orElseThrow(() -> new IllegalStateException("HDFS properties are not provided!"))));
         break;
       case LOCAL:
         baseDir = new File(parameters.getLocalDestinationDirectory());

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/DocumentArchivingProperties.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/DocumentArchivingProperties.java
@@ -23,7 +23,6 @@ import static org.apache.ambari.infra.json.StringToFsPermissionConverter.toFsPer
 import static org.apache.commons.lang.StringUtils.isBlank;
 
 import java.time.Duration;
-import java.util.Optional;
 
 import org.apache.ambari.infra.job.JobProperties;
 import org.apache.ambari.infra.json.DurationToStringConverter;
@@ -40,6 +39,7 @@ public class DocumentArchivingProperties extends JobProperties<ArchivingParamete
   private String fileNameSuffixDateFormat;
   private Duration ttl;
   private SolrProperties solr;
+
   private String s3AccessFile;
   private String s3KeyPrefix;
   private String s3BucketName;
@@ -48,6 +48,8 @@ public class DocumentArchivingProperties extends JobProperties<ArchivingParamete
   private String hdfsEndpoint;
   private String hdfsDestinationDirectory;
   private FsPermission hdfsFilePermission;
+  private String hdfsKerberosPrincipal;
+  private String hdfsKerberosKeytabPath;
 
   public int getReadBlockSize() {
     return readBlockSize;
@@ -145,17 +147,6 @@ public class DocumentArchivingProperties extends JobProperties<ArchivingParamete
     this.s3Endpoint = s3Endpoint;
   }
 
-  public Optional<S3Properties> s3Properties() {
-    if (isBlank(s3BucketName))
-      return Optional.empty();
-
-    return Optional.of(new S3Properties(
-            s3AccessFile,
-            s3KeyPrefix,
-            s3BucketName,
-            s3Endpoint));
-  }
-
   public String getHdfsEndpoint() {
     return hdfsEndpoint;
   }
@@ -178,6 +169,22 @@ public class DocumentArchivingProperties extends JobProperties<ArchivingParamete
 
   public void setHdfsDestinationDirectory(String hdfsDestinationDirectory) {
     this.hdfsDestinationDirectory = hdfsDestinationDirectory;
+  }
+
+  public String getHdfsKerberosPrincipal() {
+    return hdfsKerberosPrincipal;
+  }
+
+  public void setHdfsKerberosPrincipal(String hdfsKerberosPrincipal) {
+    this.hdfsKerberosPrincipal = hdfsKerberosPrincipal;
+  }
+
+  public String getHdfsKerberosKeytabPath() {
+    return hdfsKerberosKeytabPath;
+  }
+
+  public void setHdfsKerberosKeytabPath(String hdfsKerberosKeytabPath) {
+    this.hdfsKerberosKeytabPath = hdfsKerberosKeytabPath;
   }
 
   private int getIntJobParameter(JobParameters jobParameters, String parameterName, int defaultValue) {
@@ -203,6 +210,8 @@ public class DocumentArchivingProperties extends JobProperties<ArchivingParamete
     archivingParameters.setHdfsEndpoint(jobParameters.getString("hdfsEndpoint", hdfsEndpoint));
     archivingParameters.setHdfsDestinationDirectory(jobParameters.getString("hdfsDestinationDirectory", hdfsDestinationDirectory));
     archivingParameters.setHdfsFilePermission(toFsPermission(jobParameters.getString("hdfsFilePermission", FsPermissionToStringConverter.toString(hdfsFilePermission))));
+    archivingParameters.setHdfsKerberosPrincipal(jobParameters.getString("hdfsKerberosPrincipal", hdfsKerberosPrincipal));
+    archivingParameters.setHdfsKerberosKeytabPath(jobParameters.getString("hdfsKerberosKeytabPath", hdfsKerberosKeytabPath));
     archivingParameters.setSolr(solr.merge(jobParameters));
     archivingParameters.setStart(jobParameters.getString("start"));
     archivingParameters.setEnd(jobParameters.getString("end"));

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/HdfsProperties.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/HdfsProperties.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.infra.job.archive;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+
+import org.apache.hadoop.fs.permission.FsPermission;
+
+public class HdfsProperties {
+  private static final String DEFAULT_FILE_PERMISSION = "640";
+
+  private final String hdfsEndpoint;
+  private final String hdfsDestinationDirectory;
+  private final FsPermission hdfsFilePermission;
+  private final String hdfsKerberosPrincipal;
+  private final String hdfsKerberosKeytabPath;
+
+  public HdfsProperties(String hdfsEndpoint, String hdfsDestinationDirectory, FsPermission hdfsFilePermission, String hdfsKerberosPrincipal, String hdfsKerberosKeytabPath) {
+    this.hdfsEndpoint = hdfsEndpoint;
+    this.hdfsDestinationDirectory = hdfsDestinationDirectory;
+    this.hdfsFilePermission = hdfsFilePermission == null ? new FsPermission(DEFAULT_FILE_PERMISSION) : hdfsFilePermission;
+    this.hdfsKerberosPrincipal = hdfsKerberosPrincipal;
+    this.hdfsKerberosKeytabPath = hdfsKerberosKeytabPath;
+  }
+
+  public String getHdfsEndpoint() {
+    return hdfsEndpoint;
+  }
+
+  public String getHdfsDestinationDirectory() {
+    return hdfsDestinationDirectory;
+  }
+
+  public FsPermission getHdfsFilePermission() {
+    return hdfsFilePermission;
+  }
+
+  public String getHdfsKerberosPrincipal() {
+    return hdfsKerberosPrincipal;
+  }
+
+  public String getHdfsKerberosKeytabPath() {
+    return hdfsKerberosKeytabPath;
+  }
+
+  @Override
+  public String toString() {
+    return "HdfsProperties{" +
+            "hdfsEndpoint='" + hdfsEndpoint + '\'' +
+            ", hdfsDestinationDirectory='" + hdfsDestinationDirectory + '\'' +
+            ", hdfsFilePermission=" + hdfsFilePermission +
+            ", hdfsKerberosPrincipal='" + hdfsKerberosPrincipal + '\'' +
+            ", hdfsKerberosKeytabPath='" + hdfsKerberosKeytabPath + '\'' +
+            '}';
+  }
+
+  public void validate() {
+    if (isBlank(hdfsDestinationDirectory))
+      throw new IllegalArgumentException("The property hdfsDestinationDirectory can not be null or empty string!");
+
+    if (isNotBlank(hdfsKerberosPrincipal) && isBlank(hdfsKerberosKeytabPath))
+      throw new IllegalArgumentException("The property hdfsKerberosPrincipal is specified but hdfsKerberosKeytabPath is blank!");
+
+    if (isBlank(hdfsKerberosPrincipal) && isNotBlank(hdfsKerberosKeytabPath))
+      throw new IllegalArgumentException("The property hdfsKerberosKeytabPath is specified but hdfsKerberosPrincipal is blank!");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <deb.python.ver>python (&gt;= 2.6)</deb.python.ver>
     <deb.architecture>amd64</deb.architecture>
     <deb.dependency.list>${deb.python.ver}</deb.dependency.list>
-    <hadoop.version>3.0.0</hadoop.version>
+    <hadoop.version>3.1.1</hadoop.version>
     <surefire.argLine>-Xmx1024m -Xms512m</surefire.argLine>
     <zookeeper.version>3.4.6.2.3.0.0-2557</zookeeper.version>
     <ambari-metrics.version>2.7.0.0.0</ambari-metrics.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Infra Manager was not able to export documents from solr and save them to hdfs in a kerberized cluster

## How was this patch tested?
ITs passed

Manually:

1. Deploy Ambari and a cluster: zookeeper, infra-solr, logsearch, hdfs, infra-manager
2. Kerberize the cluster
3. Enable archiving for service_logs and set the destination to hdfs on Ambari UI, Infra Manager config
4. Run archiving of service_logs using infra managers rest api
5. check hdfs for archived service logs 
