### PR TITLE
AMBARI-24912 - Infra Manager: scheduled job fails with dateparse exception

### DIFF
--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/SolrQueryBuilder.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/SolrQueryBuilder.java
@@ -25,6 +25,7 @@ import static org.apache.solr.client.solrj.SolrQuery.ORDER.asc;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +34,7 @@ import org.apache.solr.client.solrj.SolrQuery;
 public class SolrQueryBuilder {
 
   public static String computeEnd(String end, Duration ttl) {
-    return computeEnd(end, OffsetDateTime.now(), ttl);
+    return computeEnd(end, OffsetDateTime.now(ZoneOffset.UTC), ttl);
   }
 
   public static String computeEnd(String end, OffsetDateTime now, Duration ttl) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use UTC time zone when a scheduled archiving job launched to calculate the end of interval of archivable document from system time

## How was this patch tested?

UTs ITs passed

Manually:
1. Deploy ambari and a cluster: zookeeper, infra-solr, infra-manager, logsearch
2. Schedule an archiving job like archive_service_logs
3. wait until its first run
4. check for archived documents  