### PR TITLE
AMBARI-24918 - Infra Manager: ssl support

### DIFF
--- a/ambari-infra-manager-it/src/test/java/org/apache/ambari/infra/Solr.java
+++ b/ambari-infra-manager-it/src/test/java/org/apache/ambari/infra/Solr.java
@@ -86,7 +86,7 @@ public class Solr {
 
   public void createSolrCollection(String collectionName) {
     logger.info("Creating collection");
-    runCommand(new String[]{"docker", "exec", "docker_solr_1", "solr", "create_collection", "-force", "-c", collectionName, "-d", Paths.get(configSetPath, "configsets", collectionName, "conf").toString(), "-n", collectionName + "_conf"});
+    runCommand(new String[]{"docker", "exec", "solr", "solr", "create_collection", "-force", "-c", collectionName, "-d", Paths.get(configSetPath, "configsets", collectionName, "conf").toString(), "-n", collectionName + "_conf"});
   }
 
   public QueryResponse query(SolrQuery query) {

--- a/ambari-infra-manager-it/src/test/java/org/apache/ambari/infra/solr/metrics/MetricsIT.java
+++ b/ambari-infra-manager-it/src/test/java/org/apache/ambari/infra/solr/metrics/MetricsIT.java
@@ -52,7 +52,7 @@ public class MetricsIT {
     logger.info("Creating new docker containers for testing Ambari Infra Solr Metrics plugin ...");
     runCommand(new String[]{shellScriptLocation, "start"});
 
-    Solr solr = new Solr("/usr/lib/ambari-infra-solr/server/solr");
+    Solr solr = new Solr();
     solr.waitUntilSolrIsUp();
     solr.createSolrCollection(HADOOP_LOGS_COLLECTION);
 

--- a/ambari-infra-manager/docker/docker-compose.yml
+++ b/ambari-infra-manager/docker/docker-compose.yml
@@ -15,6 +15,7 @@
 version: '3.3'
 services:
   zookeeper:
+    container_name: zookeeper
     image: zookeeper:${ZOOKEEPER_VERSION:-3.4.10}
     restart: always
     hostname: zookeeper
@@ -27,6 +28,7 @@ services:
       ZOO_SERVERS: server.1=zookeeper:2888:3888
   solr:
 #  TODO: use infra-solr
+    container_name: solr
     image: solr:${SOLR_VERSION:-7.5.0}
     restart: always
     hostname: solr
@@ -47,6 +49,7 @@ services:
     volumes:
       - $AMBARI_INFRA_LOCATION/ambari-infra-manager/docker/configsets:/opt/solr/configsets
   fakes3:
+    container_name: fakes3
     image: localstack/localstack
     hostname: fakes3
     ports:
@@ -61,6 +64,7 @@ services:
     env_file:
       - Profile
   namenode:
+    container_name: hdfs_namenode
     image: flokkr/hadoop-hdfs-namenode:${HADOOP_VERSION:-3.0.0}
     hostname: namenode
     ports:
@@ -73,6 +77,7 @@ services:
     networks:
       - infra-network
   datanode:
+    container_name: hdfs_datanode
     image: flokkr/hadoop-hdfs-datanode:${HADOOP_VERSION:-3.0.0}
     links:
       - namenode
@@ -81,6 +86,7 @@ services:
     networks:
       - infra-network
   inframanager:
+    container_name: inframanager
     image: ambari-infra-manager:v1.0
     restart: always
     hostname: infra-manager.apache.org

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/CompositeSecret.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/CompositeSecret.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.infra.conf.security;
+
+import java.util.Optional;
+
+public class CompositeSecret implements Secret {
+  private Secret[] secrets;
+
+  public CompositeSecret(Secret... secrets) {
+    this.secrets = secrets;
+  }
+
+  @Override
+  public Optional<String> get() {
+    for (Secret secret : secrets) {
+      Optional<String> optionalPassword = secret.get();
+      if (optionalPassword.isPresent())
+        return optionalPassword;
+    }
+    return Optional.empty();
+  }
+}

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/EnvironmentalSecret.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/EnvironmentalSecret.java
@@ -20,9 +20,16 @@ package org.apache.ambari.infra.conf.security;
 
 import java.util.Optional;
 
-public class SecurityEnvironment implements PasswordStore {
+public class EnvironmentalSecret implements Secret {
+
+  private final String environmentalVariableName;
+
+  public EnvironmentalSecret(String environmentalVariableName) {
+    this.environmentalVariableName = environmentalVariableName;
+  }
+
   @Override
-  public Optional<String> getPassword(String propertyName) {
-    return Optional.ofNullable(System.getenv(propertyName));
+  public Optional<String> get() {
+    return Optional.ofNullable(System.getenv(environmentalVariableName));
   }
 }

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/HadoopCredential.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/HadoopCredential.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.infra.conf.security;
+
+import java.util.Optional;
+
+public class HadoopCredential implements Secret {
+
+  private final HadoopCredentialStore hadoopCredentialStore;
+  private final String propertyName;
+
+  public HadoopCredential(HadoopCredentialStore hadoopCredentialStore, String propertyName) {
+    this.propertyName = propertyName;
+    this.hadoopCredentialStore = hadoopCredentialStore;
+  }
+
+  @Override
+  public Optional<String> get() {
+    if (hadoopCredentialStore == null) {
+      return Optional.empty();
+    }
+
+    return hadoopCredentialStore.get(propertyName).map(String::new);
+  }
+}

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/HadoopCredentialStore.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/HadoopCredentialStore.java
@@ -21,13 +21,11 @@ package org.apache.ambari.infra.conf.security;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang3.ArrayUtils.isNotEmpty;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Optional;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-public class HadoopCredentialStore implements PasswordStore {
-  private static final Logger logger = LogManager.getLogger(InfraManagerSecurityConfig.class);
+public class HadoopCredentialStore {
   public static final String CREDENTIAL_STORE_PROVIDER_PATH_PROPERTY = "hadoop.security.credential.provider.path";
 
   private final String credentialStoreProviderPath;
@@ -36,8 +34,7 @@ public class HadoopCredentialStore implements PasswordStore {
     this.credentialStoreProviderPath = credentialStoreProviderPath;
   }
 
-  @Override
-  public Optional<String> getPassword(String propertyName) {
+  public Optional<char[]> get(String key) {
     try {
       if (isBlank(credentialStoreProviderPath)) {
         return Optional.empty();
@@ -45,11 +42,14 @@ public class HadoopCredentialStore implements PasswordStore {
 
       org.apache.hadoop.conf.Configuration config = new org.apache.hadoop.conf.Configuration();
       config.set(CREDENTIAL_STORE_PROVIDER_PATH_PROPERTY, credentialStoreProviderPath);
-      char[] passwordChars = config.getPassword(propertyName);
-      return (isNotEmpty(passwordChars)) ? Optional.of(new String(passwordChars)) : Optional.empty();
-    } catch (Exception e) {
-      logger.warn("Could not load password {} from credential store.", propertyName);
-      return Optional.empty();
+      char[] passwordChars = config.getPassword(key);
+      return (isNotEmpty(passwordChars)) ? Optional.of(passwordChars) : Optional.empty();
+    } catch (IOException e) {
+      throw new UncheckedIOException(String.format("Could not load password %s from credential store.", key), e);
     }
+  }
+
+  public Secret getSecret(String key) {
+    return new HadoopCredential(this, key);
   }
 }

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/S3Secrets.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/S3Secrets.java
@@ -18,8 +18,21 @@
  */
 package org.apache.ambari.infra.conf.security;
 
-import java.util.Optional;
+public class S3Secrets {
+  private final Secret s3AccessKeyId;
+  private final Secret s3SecretAccessKey;
 
-public interface PasswordStore {
-  Optional<String> getPassword(String propertyName);
+  public S3Secrets(Secret s3AccessKeyId, Secret s3SecretAccessKey) {
+    this.s3AccessKeyId = s3AccessKeyId;
+    this.s3SecretAccessKey = s3SecretAccessKey;
+  }
+
+
+  public Secret getS3AccessKeyId() {
+    return s3AccessKeyId;
+  }
+
+  public Secret getS3SecretAccessKey() {
+    return s3SecretAccessKey;
+  }
 }

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/Secret.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/Secret.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.infra.conf.security;
+
+import java.util.Optional;
+
+public interface Secret {
+  Optional<String> get();
+}

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/SslSecrets.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/security/SslSecrets.java
@@ -18,22 +18,20 @@
  */
 package org.apache.ambari.infra.conf.security;
 
-import java.util.Optional;
+public class SslSecrets {
+  private final Secret keyStorePassword;
+  private final Secret trustStorePassword;
 
-public class CompositePasswordStore implements PasswordStore {
-  private PasswordStore[] passwordStores;
-
-  public CompositePasswordStore(PasswordStore... passwordStores) {
-    this.passwordStores = passwordStores;
+  public SslSecrets(Secret keyStorePassword, Secret trustStorePassword) {
+    this.keyStorePassword = keyStorePassword;
+    this.trustStorePassword = trustStorePassword;
   }
 
-  @Override
-  public Optional<String> getPassword(String propertyName) {
-    for (PasswordStore passwordStore : passwordStores) {
-      Optional<String> optionalPassword = passwordStore.getPassword(propertyName);
-      if (optionalPassword.isPresent())
-        return optionalPassword;
-    }
-    return Optional.empty();
+  public Secret getKeyStorePassword() {
+    return keyStorePassword;
+  }
+
+  public Secret getTrustStorePassword() {
+    return trustStorePassword;
   }
 }

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/DocumentArchivingConfiguration.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/DocumentArchivingConfiguration.java
@@ -27,12 +27,11 @@ import java.io.File;
 import javax.inject.Inject;
 
 import org.apache.ambari.infra.conf.InfraManagerDataConfig;
-import org.apache.ambari.infra.conf.security.PasswordStore;
+import org.apache.ambari.infra.conf.security.S3Secrets;
 import org.apache.ambari.infra.job.AbstractJobsConfiguration;
 import org.apache.ambari.infra.job.JobContextRepository;
 import org.apache.ambari.infra.job.JobScheduler;
 import org.apache.ambari.infra.job.ObjectSource;
-import org.apache.hadoop.fs.Path;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.batch.core.Job;
@@ -91,7 +90,7 @@ public class DocumentArchivingConfiguration extends AbstractJobsConfiguration<Ar
                                            @Value("#{jobParameters[end]}") String intervalEnd,
                                            DocumentWiper documentWiper,
                                            JobContextRepository jobContextRepository,
-                                           PasswordStore passwordStore) {
+                                           S3Secrets s3Secrets) {
 
     File baseDir = new File(infraManagerDataConfig.getDataFolder(), "exporting");
     CompositeFileAction fileAction = new CompositeFileAction(new BZip2Compressor());
@@ -99,7 +98,7 @@ public class DocumentArchivingConfiguration extends AbstractJobsConfiguration<Ar
       case S3:
         fileAction.add(new S3Uploader(
                 parameters.s3Properties().orElseThrow(() -> new IllegalStateException("S3 properties are not provided!")),
-                passwordStore));
+                s3Secrets));
         break;
       case HDFS:
         org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();

--- a/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/S3AccessCsv.java
+++ b/ambari-infra-manager/src/main/java/org/apache/ambari/infra/job/archive/S3AccessCsv.java
@@ -25,31 +25,40 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.UncheckedIOException;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.ambari.infra.conf.security.PasswordStore;
+import org.apache.ambari.infra.conf.security.Secret;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class S3AccessCsv implements PasswordStore {
+public class S3AccessCsv implements Secret {
   private static final Logger logger = LogManager.getLogger(S3AccessCsv.class);
+  public static final String ACCESS_KEY_ID = "Access key ID";
+  public static final String SECRET_ACCESS_KEY = "Secret access key";
 
-  public static S3AccessCsv file(String path) {
+
+  public static S3AccessCsv file(String path, String propertyName) {
     try {
-      return new S3AccessCsv(new FileReader(path));
+      return new S3AccessCsv(new FileReader(path), propertyName);
     } catch (FileNotFoundException e) {
       throw new UncheckedIOException(e);
     }
   }
 
-  private Map<String, String> passwordMap = new HashMap<>();
+  private final Reader reader;
+  private final String propertyName;
 
-  public S3AccessCsv(Reader reader) {
+  S3AccessCsv(Reader reader, String propertyName) {
+    this.reader = reader;
+    this.propertyName = propertyName;
+  }
+
+  @Override
+  public Optional<String> get() {
     try (CSVParser csvParser = CSVParser.parse(reader, DEFAULT.withHeader(
             S3AccessKeyNames.AccessKeyId.getCsvName(), S3AccessKeyNames.SecretAccessKey.getCsvName()))) {
       Iterator<CSVRecord> iterator = csvParser.iterator();
@@ -62,8 +71,8 @@ public class S3AccessCsv implements PasswordStore {
         throw new S3AccessCsvFormatException("Csv file contains less than 2 columns!");
       }
 
-      checkColumnExists(record, S3AccessKeyNames.AccessKeyId);
-      checkColumnExists(record, S3AccessKeyNames.SecretAccessKey);
+      checkColumnExists(record, ACCESS_KEY_ID);
+      checkColumnExists(record, SECRET_ACCESS_KEY);
 
       if (!iterator.hasNext()) {
         throw new S3AccessCsvFormatException("Csv file contains header only!");
@@ -72,23 +81,15 @@ public class S3AccessCsv implements PasswordStore {
       record = iterator.next();
 
       Map<String, Integer> header = csvParser.getHeaderMap();
-      for (S3AccessKeyNames keyNames : S3AccessKeyNames.values())
-        passwordMap.put(keyNames.getEnvVariableName(), record.get(header.get(keyNames.getCsvName())));
+      return Optional.ofNullable(record.get(header.get(propertyName)));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
-    } catch (S3AccessCsvFormatException e) {
-      logger.warn("Unable to parse csv file: {}", e.getMessage());
     }
   }
 
-  private void checkColumnExists(CSVRecord record, S3AccessKeyNames s3AccessKeyName) {
-    if (!s3AccessKeyName.getCsvName().equals(record.get(s3AccessKeyName.getCsvName()))) {
-      throw new S3AccessCsvFormatException(String.format("Csv file does not contain the required column: '%s'", s3AccessKeyName.getCsvName()));
+  private void checkColumnExists(CSVRecord record, String s3AccessKeyName) {
+    if (!s3AccessKeyName.equals(record.get(s3AccessKeyName))) {
+      throw new S3AccessCsvFormatException(String.format("Csv file does not contain the required column: '%s'", s3AccessKeyName));
     }
-  }
-
-  @Override
-  public Optional<String> getPassword(String propertyName) {
-    return Optional.ofNullable(passwordMap.get(propertyName));
   }
 }

--- a/ambari-infra-manager/src/test/java/org/apache/ambari/infra/conf/security/CompositeSecretTest.java
+++ b/ambari-infra-manager/src/test/java/org/apache/ambari/infra/conf/security/CompositeSecretTest.java
@@ -1,11 +1,11 @@
 package org.apache.ambari.infra.conf.security;
 
-import org.junit.Test;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 import java.util.Optional;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import org.junit.Test;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -25,24 +25,24 @@ import static org.junit.Assert.assertThat;
  * specific language governing permissions and limitations
  * under the License.
  */
-public class CompositePasswordStoreTest {
+public class CompositeSecretTest {
   @Test
   public void testGetPasswordReturnNullIfNoPasswordStoresWereAdded() {
-    assertThat(new CompositePasswordStore().getPassword("any").isPresent(), is(false));
+    assertThat(new CompositeSecret().get().isPresent(), is(false));
   }
 
   @Test
   public void testGetPasswordReturnNullIfPasswordNotFoundInAnyStore() {
-    assertThat(new CompositePasswordStore((prop) -> Optional.empty(), (prop) -> Optional.empty()).getPassword("any").isPresent(), is(false));
+    assertThat(new CompositeSecret(Optional::empty, Optional::empty).get().isPresent(), is(false));
   }
 
   @Test
   public void testGetPasswordReturnPasswordFromFirstStoreIfExists() {
-    assertThat(new CompositePasswordStore((prop) -> Optional.of("Pass"), (prop) -> Optional.empty()).getPassword("any").get(), is("Pass"));
+    assertThat(new CompositeSecret(() -> Optional.of("Pass"), Optional::empty).get().get(), is("Pass"));
   }
 
   @Test
   public void testGetPasswordReturnPasswordFromSecondStoreIfNotExistsInFirst() {
-    assertThat(new CompositePasswordStore((prop) -> Optional.empty(), (prop) -> Optional.of("Pass")).getPassword("any").get(), is("Pass"));
+    assertThat(new CompositeSecret(Optional::empty, () -> Optional.of("Pass")).get().get(), is("Pass"));
   }
 }

--- a/ambari-infra-manager/src/test/java/org/apache/ambari/infra/job/archive/S3AccessCsvTest.java
+++ b/ambari-infra-manager/src/test/java/org/apache/ambari/infra/job/archive/S3AccessCsvTest.java
@@ -1,11 +1,12 @@
 package org.apache.ambari.infra.job.archive;
 
-import org.junit.Test;
+import static org.apache.ambari.infra.job.archive.S3AccessCsv.ACCESS_KEY_ID;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 import java.io.StringReader;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import org.junit.Test;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -33,38 +34,33 @@ public class S3AccessCsvTest {
   private static final String ANY_CSV_FILE = "Column1,Column2\n" +
           "Foo,Bar\n";
 
-  @Test
+  @Test(expected = S3AccessCsvFormatException.class)
   public void testGetPasswordReturnsNullIfInputIsEmpty() {
-    S3AccessCsv accessCsv = new S3AccessCsv(new StringReader(""));
-    assertThat(accessCsv.getPassword(S3AccessKeyNames.AccessKeyId.getEnvVariableName()).isPresent(), is(false));
-    assertThat(accessCsv.getPassword(S3AccessKeyNames.SecretAccessKey.getEnvVariableName()).isPresent(), is(false));
+    S3AccessCsv accessCsv = new S3AccessCsv(new StringReader(""), ACCESS_KEY_ID);
+    assertThat(accessCsv.get().isPresent(), is(false));
   }
 
   @Test
   public void testGetPasswordReturnsAccessAndSecretKeyIfInputIsAValidS3AccessFile() {
-    S3AccessCsv accessCsv = new S3AccessCsv(new StringReader(VALID_ACCESS_FILE));
-    assertThat(accessCsv.getPassword(S3AccessKeyNames.AccessKeyId.getEnvVariableName()).get(), is("someKey"));
-    assertThat(accessCsv.getPassword(S3AccessKeyNames.SecretAccessKey.getEnvVariableName()).get(), is("someSecret"));
+    S3AccessCsv accessCsv = new S3AccessCsv(new StringReader(VALID_ACCESS_FILE), ACCESS_KEY_ID);
+    assertThat(accessCsv.get().get(), is("someKey"));
   }
 
-  @Test
-  public void testGetPasswordReturnsNullIfNotAValidS3AccessFileProvided() {
-    S3AccessCsv accessCsv = new S3AccessCsv(new StringReader(ANY_CSV_FILE));
-    assertThat(accessCsv.getPassword(S3AccessKeyNames.AccessKeyId.getEnvVariableName()).isPresent(), is(false));
-    assertThat(accessCsv.getPassword(S3AccessKeyNames.SecretAccessKey.getEnvVariableName()).isPresent(), is(false));
+  @Test(expected = S3AccessCsvFormatException.class)
+  public void testGetPasswordThrowsExceptionIfNotAValidS3AccessFileProvided() {
+    S3AccessCsv accessCsv = new S3AccessCsv(new StringReader(ANY_CSV_FILE), ACCESS_KEY_ID);
+    assertThat(accessCsv.get().isPresent(), is(false));
   }
 
-  @Test
-  public void testGetPasswordReturnsNullIfAHeaderOnlyS3AccessFileProvided() {
-    S3AccessCsv accessCsv = new S3AccessCsv(new StringReader("Access key ID,Secret access key\n"));
-    assertThat(accessCsv.getPassword(S3AccessKeyNames.AccessKeyId.getEnvVariableName()).isPresent(), is(false));
-    assertThat(accessCsv.getPassword(S3AccessKeyNames.SecretAccessKey.getEnvVariableName()).isPresent(), is(false));
+  @Test(expected = S3AccessCsvFormatException.class)
+  public void testGetPasswordThrowsExceptionIfAHeaderOnlyS3AccessFileProvided() {
+    S3AccessCsv accessCsv = new S3AccessCsv(new StringReader("Access key ID,Secret access key\n"), ACCESS_KEY_ID);
+    assertThat(accessCsv.get().isPresent(), is(false));
   }
 
-  @Test
-  public void testGetPasswordReturnsNullIfOnlyOneValidColumnProvided() {
-    S3AccessCsv accessCsv = new S3AccessCsv(new StringReader("Access key ID,Column\n"));
-    assertThat(accessCsv.getPassword(S3AccessKeyNames.AccessKeyId.getEnvVariableName()).isPresent(), is(false));
-    assertThat(accessCsv.getPassword(S3AccessKeyNames.SecretAccessKey.getEnvVariableName()).isPresent(), is(false));
+  @Test(expected = S3AccessCsvFormatException.class)
+  public void testGetPasswordThrowsExceptionIfOnlyOneValidColumnProvided() {
+    S3AccessCsv accessCsv = new S3AccessCsv(new StringReader("Access key ID,Column\n"), ACCESS_KEY_ID);
+    assertThat(accessCsv.get().isPresent(), is(false));
   }
 }

--- a/ambari-infra-solr-plugin/docker/infra-solr-docker-compose.sh
+++ b/ambari-infra-solr-plugin/docker/infra-solr-docker-compose.sh
@@ -101,8 +101,8 @@ function create_collection() {
   pushd $sdir/../
   local AMBARI_SOLR_MANAGER_LOCATION=$(pwd)
   cd $AMBARI_SOLR_MANAGER_LOCATION/docker
-  docker exec docker_solr_1 solr create_collection -force -c hadoop_logs -d /usr/lib/ambari-infra-solr/server/solr/configsets/hadoop_logs/conf -n hadoop_logs_conf
-  docker exec docker_solr_1 solr create_collection -force -c audit_logs -d /usr/lib/ambari-infra-solr/server/solr/configsets/audit_logs/conf -n audit_logs_conf
+  docker exec solr solr create_collection -force -c hadoop_logs -d /usr/lib/ambari-infra-solr/server/solr/configsets/hadoop_logs/conf -n hadoop_logs_conf
+  docker exec solr solr create_collection -force -c audit_logs -d /usr/lib/ambari-infra-solr/server/solr/configsets/audit_logs/conf -n audit_logs_conf
   popd
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Handle java.net.ssl related system properties:
- use keystore and trustsore for communicating with Solr
- turn on https for Infra Manager REST api
2. Refactor Infra Manager security package: a secret can have different property names in different secret stores
3. Set container names in docker environment because if component name is not specified in the docker-compose file the generated container name contains a random sequence.  

## How was this patch tested?

ITs UTs passed

Manually:
1. Deploy Ambari and a cluster: Zookeeper, Infra Solr, Infra Manager, Logsearch
2. Generate self signed certificates
3. Enable ssl for Infra Solr, Logsearch and Infra Manager using the generated certificates
4. Enable archiving job
5. Run archiving job
6. Check that archive files exists in the destination folder