### PR TITLE
[AMBARI-18361] Avoid unnecessary compilation

### DIFF
--- a/ambari-infra-manager/pom.xml
+++ b/ambari-infra-manager/pom.xml
@@ -51,11 +51,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>${jdk.version}</source>
-          <target>${jdk.version}</target>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -303,7 +298,7 @@
       <artifactId>jersey-media-json-jettison</artifactId>
       <version>${jersey.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>

--- a/ambari-infra-solr-plugin/pom.xml
+++ b/ambari-infra-solr-plugin/pom.xml
@@ -60,11 +60,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>${jdk.version}</source>
-          <target>${jdk.version}</target>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -194,10 +194,11 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.3</version>
         <configuration>
           <source>${jdk.version}</source>
           <target>${jdk.version}</target>
+          <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix for:

1. all `ambari-infra-manager` classes are recompiled even if none has changed
2. all classes are recompiled in each submodule that has any changed java source

```
$ mvn clean test-compile
$ mvn test-compile
...
[INFO] --- maven-compiler-plugin:3.0:compile (default-compile) @ ambari-infra-manager ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 100 source files to ambari-infra-manager/target/classes
...
$ touch ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/InfraManagerDataConfig.java
$ mvn test-compile
...
[INFO] --- maven-compiler-plugin:3.0:compile (default-compile) @ ambari-infra-manager ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 100 source files to ambari-infra-manager/target/classes
```

## How was this patch tested?

```
$ mvn clean test-compile
$ mvn test-compile
...
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ ambari-infra-manager ---
[INFO] Nothing to compile - all classes are up to date
...
$ touch ambari-infra-manager/src/main/java/org/apache/ambari/infra/conf/InfraManagerDataConfig.java
$ mvn test-compile
...
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ ambari-infra-manager ---
[INFO] Compiling 1 source file to ambari-infra-manager/target/classes
```

```
$ mvn clean test
...
[INFO] BUILD SUCCESS
$ mvn test
...
[INFO] BUILD SUCCESS
```