### PR TITLE
AMBARI-24987 - Infra Manager: parse logs by Logsearch

### DIFF
--- a/ambari-infra-manager/pom.xml
+++ b/ambari-infra-manager/pom.xml
@@ -364,6 +364,10 @@
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-server</artifactId>
         </exclusion>
@@ -569,6 +573,17 @@
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
       <version>2.3.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-web</artifactId>
+      <version>${log4j2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
 
   </dependencies>

--- a/ambari-infra-manager/src/main/resources/log4j2.xml
+++ b/ambari-infra-manager/src/main/resources/log4j2.xml
@@ -24,7 +24,7 @@
       <Layout type="PatternLayout" pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}:%L - %msg%n" />
     </Appender>
     <RollingFile name="File" fileName="${logging.file}" filePattern="${logging.file}-%i-%d{yyyy-MM-dd}">
-      <PatternLayout pattern="%d [%t] %-5p %C{6} (%F:%L) - %m%n" />
+      <PatternLayout pattern="%d{ISO8601} [%t] %-5p %C{6} (%F:%L) - %m%n" />
       <Policies>
         <TimeBasedTriggeringPolicy />
         <SizeBasedTriggeringPolicy size="10 MB"/>

--- a/ambari-infra-manager/src/main/resources/log4j2.xml
+++ b/ambari-infra-manager/src/main/resources/log4j2.xml
@@ -24,7 +24,7 @@
       <Layout type="PatternLayout" pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}:%L - %msg%n" />
     </Appender>
     <RollingFile name="File" fileName="${logging.file}" filePattern="${logging.file}-%i-%d{yyyy-MM-dd}">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}:%L - %msg%n" />
+      <PatternLayout pattern="%d [%t] %-5p %C{6} (%F:%L) - %m%n" />
       <Policies>
         <TimeBasedTriggeringPolicy />
         <SizeBasedTriggeringPolicy size="10 MB"/>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <zookeeper.version>3.4.6.2.3.0.0-2557</zookeeper.version>
     <ambari-metrics.version>2.7.0.0.0</ambari-metrics.version>
     <skipSurefireTests>false</skipSurefireTests>
+    <log4j2.version>2.10.0</log4j2.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Change the rolling file appenders log entry pattern: log date-time to ISO8601 format, log java file and line number
* Eliminate `log4j 1` dependencies and use `log4j-1.2-api` for 3rd party components which are depends on `log4j 1`
* Add 'log4j-web' to eliminate warning
```
2018-12-04 15:52:10,943 main INFO Log4j appears to be running in a Servlet environment, but there's no log4j-web module available. If you want better web container support, please add the log4j-web JAR to your web archive or server lib directory.
```
Since this log entry is in a different format it caused Logfeeder to stop parsing infra manager logs.

## How was this patch tested?

UTs and ITs passed

Manually:
1. Deploy Ambari and a cluster: Zookeeper, Infra Solr, Logsearch, Infra Manager
2. Start all components
3. Login to Logsearch Portal and search for Infra Manager logs

