### PR TITLE
AMBARI-25935: Upgrade Ambari Infra Solr to version 8 and ensure it is…

### DIFF
--- a/ambari-infra-assembly/build.xml
+++ b/ambari-infra-assembly/build.xml
@@ -31,12 +31,6 @@
       <fileset dir="${project.build.directory}/solr-${solr.version}"/>
     </move>
 
-    <delete
-      file="${project.build.directory}/solr/server/solr-webapp/webapp/WEB-INF/lib/${common-fileupload.old.jar.name}"/>
-    <get src="${common-fileupload.location.url}" dest="target/${common-fileupload.jar.name}" usetimestamp="true"/>
-    <move file="target/${common-fileupload.jar.name}"
-          toDir="${project.build.directory}/solr/server/solr-webapp/webapp/WEB-INF/lib/"/>
-
     <copy file="${infra.solr.plugin.dir}/target/ambari-infra-solr-plugin-${project.version}.jar"
           toDir="${project.build.directory}/solr/server/solr-webapp/webapp/WEB-INF/lib/"/>
     <copy file="${infra.solr.plugin.dir}/target/libs/ambari-metrics-common-${ambari-metrics.version}.jar"

--- a/ambari-infra-assembly/pom.xml
+++ b/ambari-infra-assembly/pom.xml
@@ -41,9 +41,6 @@
     <infra-manager.dir>${project.basedir}/../ambari-infra-manager</infra-manager.dir>
     <infra-manager.mapping.path>${mapping.base.path}/${infra-manager.package.name}</infra-manager.mapping.path>
     <infra-manager.conf.mapping.path>${infra-manager.mapping.path}/conf</infra-manager.conf.mapping.path>
-    <common-fileupload.location.url>http://central.maven.org/maven2/commons-fileupload/commons-fileupload/1.3.3/commons-fileupload-1.3.3.jar</common-fileupload.location.url>
-    <common-fileupload.jar.name>commons-fileupload-1.3.3.jar</common-fileupload.jar.name>
-    <common-fileupload.old.jar.name>commons-fileupload-1.3.2.jar</common-fileupload.old.jar.name>
     <jenkins.docker.folder>../jenkins/containers</jenkins.docker.folder>
   </properties>
 

--- a/ambari-infra-solr-client/build.xml
+++ b/ambari-infra-solr-client/build.xml
@@ -36,8 +36,7 @@
     </copy>
     <mkdir dir="target/migrate"/>
     <mkdir dir="target/migrate/data"/>
-    <get src="${lucene6-core.url}" dest="target/migrate/${lucene6-core-jar.name}" usetimestamp="true"/>
-    <get src="${lucene6-backward-codecs.url}" dest="target/migrate/${lucene6-backward-codecs-jar.name}" usetimestamp="true"/>
+    
     <copy todir="target/package/migrate" includeEmptyDirs="no">
       <fileset file="target/migrate/*.jar"/>
       <fileset file="target/package/libs/lucene-core-${solr.version}.jar"/>

--- a/ambari-infra-solr-client/pom.xml
+++ b/ambari-infra-solr-client/pom.xml
@@ -29,14 +29,6 @@
 
   <artifactId>ambari-infra-solr-client</artifactId>
 
-  <properties>
-    <lucene6.version>6.6.2</lucene6.version>
-    <lucene6-core-jar.name>lucene-core-${lucene6.version}.jar</lucene6-core-jar.name>
-    <lucene6-core.url>http://central.maven.org/maven2/org/apache/lucene/lucene-core/${lucene6.version}/${lucene6-core-jar.name}</lucene6-core.url>
-    <lucene6-backward-codecs-jar.name>lucene-backward-codecs-${lucene6.version}.jar</lucene6-backward-codecs-jar.name>
-    <lucene6-backward-codecs.url>http://central.maven.org/maven2/org/apache/lucene/lucene-backward-codecs/${lucene6.version}/${lucene6-backward-codecs-jar.name}</lucene6-backward-codecs.url>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.solr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,15 +26,15 @@
   <properties>
     <revision>3.0.0.0-SNAPSHOT</revision>
     <jdk.version>1.8</jdk.version>
-    <solr.version>7.6.0</solr.version>
+    <solr.version>8.11.2</solr.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <python.ver>python &gt;= 2.6</python.ver>
     <deb.python.ver>python (&gt;= 2.6)</deb.python.ver>
     <deb.architecture>amd64</deb.architecture>
     <deb.dependency.list>${deb.python.ver}</deb.dependency.list>
-    <hadoop.version>3.1.1</hadoop.version>
+    <hadoop.version>3.3.4</hadoop.version>
     <surefire.argLine>-Xmx1024m -Xms512m</surefire.argLine>
-    <zookeeper.version>3.4.6.2.3.0.0-2557</zookeeper.version>
+    <zookeeper.version>3.5.9</zookeeper.version>
     <ambari-metrics.version>2.7.0.0.0</ambari-metrics.version>
     <skipSurefireTests>false</skipSurefireTests>
     <log4j2.version>2.10.0</log4j2.version>


### PR DESCRIPTION
… consistent with the Solr version in Ambari 2.8 stack

## What changes were proposed in this pull request?

Remove the dependency on "fileupload" as compared to Solr 7, since Solr 8 no longer depends on "fileupload".
Remove the copying of "lucene6-core-jar" in the Infra client, since Solr 8's "lib" directory includes "lucene8-core". 
Solr 8 uses lucene8.

## How was this patch tested?

manual test 
![image](https://user-images.githubusercontent.com/18082602/236596538-ab1ad8b9-c776-4f40-abb2-21e7025bb995.png)


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
