### PR TITLE
Use https to download solr tarball

### DIFF
--- a/ambari-infra-assembly/pom.xml
+++ b/ambari-infra-assembly/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <mapping.base.path>/usr/lib</mapping.base.path>
-    <solr.tar>http://archive.apache.org/dist/lucene/solr/${solr.version}/solr-${solr.version}.tgz</solr.tar>
+    <solr.tar>https://archive.apache.org/dist/lucene/solr/${solr.version}/solr-${solr.version}.tgz</solr.tar>
     <solr.mapping.path>${mapping.base.path}/ambari-infra-solr</solr.mapping.path>
     <solr.package.name>ambari-infra-solr</solr.package.name>
     <solr.client.package.name>ambari-infra-solr-client</solr.client.package.name>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use https to download solr tarball

## How was this patch tested?

From build log:
<img width="2238" height="237" alt="Bildschirmfoto_20260526_001632" src="https://github.com/user-attachments/assets/d3c6d2e1-a47a-414e-89d0-16dfa3287699" />

