### PR TITLE
[RFC] Retire hortonworks repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,6 @@
 
   <repositories>
     <repository>
-      <id>apache-hadoop</id>
-      <name>hdp</name>
-      <url>http://repo.hortonworks.com/content/groups/public/</url>
-    </repository>
-    <repository>
       <id>oss.sonatype.org</id>
       <name>OSS Sonatype Staging</name>
       <url>https://oss.sonatype.org/content/groups/staging</url>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The old Hortonworks repository appears abandoned, no HTTPS is available or certificates are expired. This pull request proposes to remove the repository from the project.

## How was this patch tested?

Already without this patch, no files are actually downloaded from the repository. Builds succeed without error with this patch applied. 